### PR TITLE
use the JCESecureRandomProvider to generate random IDs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:22.1.1'
     compile 'com.google.android.gms:play-services:7.0.0'
+    compile 'org.whispersystems:curve25519-android:0.2.4'
     compile 'io.reactivex:rxandroid:0.25.0'
     compile 'com.squareup.retrofit:retrofit:1.9.0'
     compile 'com.squareup.okhttp:okhttp-urlconnection:2.4.0'

--- a/app/src/main/java/org/tlc/whereat/model/UserLocation.java
+++ b/app/src/main/java/org/tlc/whereat/model/UserLocation.java
@@ -12,7 +12,7 @@ import com.google.gson.reflect.TypeToken;
 import java.lang.reflect.Type;
 import java.util.List;
 
-import static java.util.UUID.randomUUID;
+import org.whispersystems.curve25519.JCESecureRandomProvider;
 
 public class UserLocation implements Parcelable {
 
@@ -24,7 +24,10 @@ public class UserLocation implements Parcelable {
     // CONSTRUCTORS
 
     public static UserLocation valueOf(Location l){
-        String id = randomUUID().toString();
+        JCESecureRandomProvider srp = new JCESecureRandomProvider();
+        byte[] idBytes = new byte[32];
+        srp.nextBytes(idBytes);
+        String id = new String(idBytes);
         return valueOf(id, l);
     }
 


### PR DESCRIPTION
Instead of using randomUUID, we use the interface to JCESecureRandomProvider
provided by curve25519-java to generate random numbers to turn into IDs. Step 1 for using curve25519 for our crypto needs!