### PR TITLE
VERSION BUMP

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,8 +27,8 @@ android {
         applicationId "org.tlc.whereat"
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 2
-        versionName "1.01"
+        versionCode 3
+        versionName "1.0.2"
     }
     signingConfigs {
         release {

--- a/app/src/main/java/org/tlc/whereat/modules/api/WhereatApiClient.java
+++ b/app/src/main/java/org/tlc/whereat/modules/api/WhereatApiClient.java
@@ -17,6 +17,7 @@ import rx.Observable;
 public class WhereatApiClient implements WhereatApi {
 
     private static String mRoot = "https://api.whereat.io";
+    //private static String mRoot = "https: //api-dev.whereat.io"; // for testing
     private static WhereatApiClient mInstance;
     private WhereatApi mApi;
 


### PR DESCRIPTION
1.0.1 -> 1.0.2

Changes:

* Delete locally stored locations every minute
* User may change location sharing intervals
* User may change local data time-to-live
* Eliminate long-pressing power button
* Clicking power button toggles background location sharing
* Link to security best practices page on load