### PR TITLE
DEBUG: Fix sequence for enabling Play Services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /build
 /*/build/
 app-release.apk
+*.apk
 
 # Generated files
 bin/

--- a/app/src/main/java/org/tlc/whereat/modules/pubsub/broadcasters/LocPubBroadcasters.java
+++ b/app/src/main/java/org/tlc/whereat/modules/pubsub/broadcasters/LocPubBroadcasters.java
@@ -79,7 +79,7 @@ public class LocPubBroadcasters {
         Dispatcher.broadcast(mLbm, mCtx, i);
     }
 
-    public void playServicesDisable(){
+    public void playServicesDisabled(){
         Intent i = new Intent().setAction(ACTION_PLAY_SERVICES_DISABLED);
         Dispatcher.broadcast(mLbm, mCtx, i);
     }

--- a/app/src/main/java/org/tlc/whereat/services/LocationPublisher.java
+++ b/app/src/main/java/org/tlc/whereat/services/LocationPublisher.java
@@ -72,13 +72,14 @@ public class LocationPublisher extends Service
 
     @Override
     public void onCreate(){
+        mBroadcast = LocPubBroadcasters.getInstance(this);
         Log.i(TAG, "Location service created.");
     }
 
     @Override
     public int onStartCommand(Intent i, int flags, int startId){
         if (playServicesDisabled()) {
-            mBroadcast.playServicesDisable();
+            mBroadcast.playServicesDisabled();
             return Service.START_REDELIVER_INTENT;
         }
         else {
@@ -105,8 +106,8 @@ public class LocationPublisher extends Service
         mWhereatClient = WhereatApiClient.getInstance();
         mDao = new LocationDao(this);
         mScheduler = Scheduler.getInstance(this);
-        mBroadcast = LocPubBroadcasters.getInstance(this);
         mLocProvider = FusedLocationApi;
+        if (mBroadcast == null) mBroadcast = LocPubBroadcasters.getInstance(this);
 
         mLocSub = mBroadcast::map;
 
@@ -258,10 +259,10 @@ public class LocationPublisher extends Service
             .subscribe(mLocSub);
     }
 
-    private boolean playServicesDisabled() {
+    protected boolean playServicesDisabled() {
         return (GooglePlayServicesUtil.isGooglePlayServicesAvailable(this) != ConnectionResult.SUCCESS);
     }
-    private boolean locationServicesDisabled(){
+    protected boolean locationServicesDisabled(){
         return Build.VERSION.SDK_INT > 19 ? newLsOff() : oldLsOff();
     }
 

--- a/app/src/test/java/org/tlc/whereat/modules/pubsub/broadcasters/LocPubBroadcastersTest.java
+++ b/app/src/test/java/org/tlc/whereat/modules/pubsub/broadcasters/LocPubBroadcastersTest.java
@@ -103,7 +103,7 @@ public class LocPubBroadcastersTest {
 
     @Test
     public void playServicesDisabled_should_broadcast_ACTION_PLAY_SERVICES_DISABLED(){
-        bc.playServicesDisable();
+        bc.playServicesDisabled();
 
         verify(bc.mLbm).sendBroadcast(intentArg.capture());
         assertThat(intentArg.getValue().getAction())

--- a/app/src/test/java/org/tlc/whereat/services/LocationPublisherTest.java
+++ b/app/src/test/java/org/tlc/whereat/services/LocationPublisherTest.java
@@ -1,9 +1,11 @@
 package org.tlc.whereat.services;
 
+import android.app.Service;
 import android.content.ComponentName;
 import android.content.SharedPreferences;
 import android.location.Location;
 import android.os.IBinder;
+import android.content.Intent;
 
 import com.google.android.gms.common.api.GoogleApiClient;
 import com.google.android.gms.location.FusedLocationProviderApi;
@@ -55,11 +57,40 @@ public class LocationPublisherTest {
 
     public static class LifeCycleMethods {
 
-        //#onStartCommand()
+        Intent i = mock(Intent.class);
+
+        @Test
+        public void onCreate_should_initializeBroadcaster(){
+            LocationPublisher lp = spy(LocationPublisher.class);
+            lp.onCreate();
+            assertThat(lp.mBroadcast).isNotNull();
+        }
+
+        @Test
+        public void onStartCommand_when_playServicesDisabled_should_triggerEnablingSequence(){
+            LocationPublisher lp = spy(LocationPublisher.class);
+            lp.mBroadcast = mock(LocPubBroadcasters.class);
+            when(lp.playServicesDisabled()).thenReturn(true);
+
+            assertThat(lp.onStartCommand(i, 0, 0)).isEqualTo(Service.START_REDELIVER_INTENT);
+            verify(lp.mBroadcast).playServicesDisabled();
+        }
+
+        @Test
+        public void onStartCommand_when_playEnabled_should_initializeAndRunTheService(){
+            LocationPublisher lp = spy(LocationPublisher.class);
+            doNothing().when(lp).initialize();
+            doNothing().when(lp).run();
+            when(lp.playServicesDisabled()).thenReturn(false);
+
+            assertThat(lp.onStartCommand(i,0,0)).isEqualTo(Service.START_STICKY);
+            verify(lp).initialize();
+            verify(lp).run();
+        }
 
         @Test
         public void initialize_should_initializePrivateFields() {
-            LocationPublisher lp = spy(new FakeLocationPublisher());
+            LocationPublisher lp = spy(LocationPublisher.class);
             when(lp.getRandomId()).thenReturn("123");
 
             lp.initialize();


### PR DESCRIPTION
__Effect on user:__

* when user first loads app and doesn't know about Play Services, app
  should guide them to set it up instead of crashing mysteriously

__Bug Fix__

* BUG: if play services disabled, app crashes with NPE
* CAUSE: `LocationPublisher` is trying to use uninitialized `mBroadcast`
  field to broadcast problem to rest of app
* FIX:
  * initialize `mBroadcast` earlier in lifecycle (in `#onCreate` instead
    of `#initialize`) so that its defined in scope of `#onStartCommand` call
  * byproduct: add tests for `#onCreate` and `#onStartCommand` methods
    of `LocationPublisher` class