### PR TITLE
Preserve polling state

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         <activity
             android:name=".activities.OnOffActivity"
             android:label="@string/app_name"
+            android:launchMode="singleInstance"
             android:configChanges="orientation|screenLayout|screenSize" >
         </activity>
 

--- a/app/src/main/java/org/tlc/whereat/activities/OnOffActivity.java
+++ b/app/src/main/java/org/tlc/whereat/activities/OnOffActivity.java
@@ -19,6 +19,7 @@ import static org.tlc.whereat.modules.ui.Toaster.shortToast;
 public class OnOffActivity extends AppCompatActivity {
 
     public static final String TAG = OnOffActivity.class.getSimpleName();
+    public static final String POLLING = "polling";
 
     protected LocPubManager mLocPubMgr;
     protected MainActivityReceivers mReceivers;
@@ -30,18 +31,18 @@ public class OnOffActivity extends AppCompatActivity {
     // LIFE CYCLE METHODS
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
+    protected void onCreate(Bundle state) {
 
-        super.onCreate(savedInstanceState);
+        super.onCreate(state);
         setContentView(R.layout.activity_main);
 
         mLocPubMgr = new LocPubManager(this);
         mReceivers = new MainActivityReceivers(this);
         mMenu = new MenuHandler(this);
-        mPolling = true;
+        mPolling = state == null || state.getBoolean(POLLING); //TODO test this!
 
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
-        findViewById(R.id.go_button).setOnClickListener(this::togglePolling);
+        initGoButton(findViewById(R.id.go_button));
     }
 
     @Override
@@ -58,7 +59,24 @@ public class OnOffActivity extends AppCompatActivity {
         mReceivers.unregister();
     }
 
+    @Override
+    protected void onDestroy(){
+        super.onDestroy();
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle state){
+        state.putBoolean(POLLING, mPolling);
+        super.onSaveInstanceState(state);
+    }
+
     // GO BUTTON HELPERS
+
+    protected void initGoButton(View v){
+        if (mPolling) v.setBackground(getDrawn(R.drawable.go_button_on));
+        else v.setBackground(getDrawn(R.drawable.go_button_off));
+        v.setOnClickListener(this::togglePolling);
+    }
 
     protected void togglePolling(View v){
         if (mPolling) stopPolling(v);

--- a/app/src/main/java/org/tlc/whereat/activities/OnOffActivity.java
+++ b/app/src/main/java/org/tlc/whereat/activities/OnOffActivity.java
@@ -39,7 +39,7 @@ public class OnOffActivity extends AppCompatActivity {
         mLocPubMgr = new LocPubManager(this);
         mReceivers = new MainActivityReceivers(this);
         mMenu = new MenuHandler(this);
-        mPolling = state == null || state.getBoolean(POLLING); //TODO test this!
+        mPolling = state == null || state.getBoolean(POLLING);
 
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
         initGoButton(findViewById(R.id.go_button));

--- a/app/src/main/java/org/tlc/whereat/services/LocationPublisher.java
+++ b/app/src/main/java/org/tlc/whereat/services/LocationPublisher.java
@@ -69,7 +69,7 @@ public class LocationPublisher extends Service
     protected long mTtl;
     protected boolean mPolling = false;
     protected long mLastPing = -1L;
-    protected boolean mStarted = false;
+    protected boolean mRunning = false;
 
     // LIFE CYCLE METHODS
 
@@ -85,10 +85,10 @@ public class LocationPublisher extends Service
             mBroadcast.playServicesDisabled();
             return Service.START_REDELIVER_INTENT;
         }
-        else if (!mStarted) {
+        else if (!mRunning) {
             initialize();
             run();
-            mStarted = true;
+            mRunning = true;
             return Service.START_STICKY;
         }
         else {
@@ -114,7 +114,6 @@ public class LocationPublisher extends Service
         mDao = new LocationDao(this);
         mScheduler = Scheduler.getInstance(this);
         mLocProvider = FusedLocationApi;
-        //if (mBroadcast == null) mBroadcast = LocPubBroadcasters.getInstance(this);
 
         mLocSub = this::record;
         mClearSub = mBroadcast::clear;


### PR DESCRIPTION
* __BUG:__
  * when switching away from OnOffActivity and back,
    changes to polling state are lost
  * as a result, button starts with wrong color, pressing it yields
    incorrect effects on location polling
* __FIX:__
  * save polling state to Bundle in `onSavedInstanceState`
    (will be incorporated to subsequent calls to `onCreate`
    if activity is stopped or destroyed)
  * make OnOffActivity a "singleInstance" activity in
    AndroidManifest
  * __NOTE:__ the latter fix has been visually verified but resists testing