### PR TITLE
AG | Update APK version number for Play Store

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,8 +27,8 @@ android {
         applicationId "org.tlc.whereat"
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 3
-        versionName "1.0.2"
+        versionCode 4
+        versionName "1.0.4"
     }
     signingConfigs {
         release {


### PR DESCRIPTION
Motivation:
- while we build the React Native version of this app, we want contributors and users 
  to be able to access the most recent version of the vestigal app
- the version at master/HEAD has several new changes, including:
  - app starts on load on the map page with location sharing on
  - preserves polling state correctly
- BUT: the version on the Play Store lacks these changes
- AND: to publish a new APK, we need to bump the version number

Actions:
- package and sign a new APK with most recent changes
- give a new version number to the APK
- publish to the Play Store

TO-DO:
- document the process of signing and publishing an APK
- figure out a strategy for sharing (or not sharing) signing credentials
